### PR TITLE
Tcpmetric

### DIFF
--- a/src/classes.py
+++ b/src/classes.py
@@ -256,11 +256,11 @@ class Router(Device):
 
             if(dynamic):
                 routPacket = RoutingPacket(self, otherDev, link, constants.ROUTING_SIZE,
-                                        self.rout_table, packetID = None, curr_loc = None,
+                                        self.rout_table, str(self.deviceID) + " ROUT", curr_loc = None,
                                         latency = link.calcExpectedLatency())
             else:
                 routPacket = RoutingPacket(self, otherDev, link, constants.ROUTING_SIZE,
-                                       self.rout_table, packetID = None, curr_loc = None)
+                                       self.rout_table, str(self.deviceID) + " ROUT", curr_loc = None)
 
             res.append((routPacket, link))
         return res

--- a/src/classes.py
+++ b/src/classes.py
@@ -339,6 +339,9 @@ class Flow:
 
         :param theoRTT: The theoretical round trip time of a packet in this flow.
         :type theoRTT: int
+
+        :param minRTT: The observed minimum rtt of a packet in this flow.
+        :type minRTT: float
         """
         self.flowID = flowID
         self.src = src
@@ -349,8 +352,12 @@ class Flow:
         self.flow_start = flow_start * constants.s_to_ms
         self.theoRTT = theoRTT
         self.actualRTT = 0
+        self.minRTT = 9999999999;
 
         self.window_size = 1
+
+        #keeps track of the first time a packet is acknowledged
+        self.first_time = 0
 
         # Congestion Control Variables
         self.packets = []
@@ -488,6 +495,11 @@ class Flow:
         # TODO: TODO: Check with TAs
         if currentTime - packet.start_time > self.actualRTT:
             self.actualRTT = currentTime - packet.start_time
+            if self.actualRTT < self.minRTT:
+                #print "minRTT: " + str(self.flowID) + " " + str(self.minRTT)
+                print "old minRTT: " + str(self.flowID) + " " + str(self.minRTT)
+                self.minRTT = self.actualRTT
+                print "new minRTT: " + str(self.flowID) + " " + str(self.minRTT)
 
         #check if actualRTT is valid
         if self.actualRTT != 0 and self.actualRTT < self.theoRTT:
@@ -630,7 +642,7 @@ class Flow:
             if(self.window_upper > len(self.packets) - 1):
                 self.window_upper = len(self.packets) - 1
 
-        print "Window size: " + str(self.window_size)
+        print "Window size: " + str(self.flowID) + " " + str(self.window_size)
         print "Window Upper: " + str(self.window_upper)
 
     def TCPFast(self, alpha):
@@ -647,7 +659,18 @@ class Flow:
 
         print "theoRTT: " + str(self.theoRTT)
         print "actualRTT: " + str(self.actualRTT)
-        newWindowSize = (self.theoRTT/self.actualRTT) * self.window_size + alpha
+
+
+        if self.flowID == "F1":
+            print "TCPFast flow1"
+
+        if self.flowID == "F2":
+            print "TCPFast flow2"
+
+        if self.flowID == "F3":
+            print "TCPFast flow3"        
+
+        newWindowSize = (self.minRTT/self.actualRTT) * self.window_size + alpha
         self.window_size = newWindowSize
 
         self.window_upper = floor(self.window_size) + self.window_lower - 1
@@ -655,7 +678,7 @@ class Flow:
         if(self.window_upper > len(self.packets) - 1):
             self.window_upper = len(self.packets) - 1
 
-        print "Window size: " + str(self.window_size)
+        print "Window size: " + str(self.flowID) + " " + str(self.window_size)
         print "Window Upper: " + str(self.window_upper)
 
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -3,8 +3,8 @@
 QUEUE_DELAY = 1
 
 # Instead of logging every event, just log once in a discrete time interval.
-# Currently set to 20ms.
-LOG_TIME_INTERVAL = 0.05
+# Currently set to 100ms.
+LOG_TIME_INTERVAL = 0.1
 
 # EPSILON_DELAY: a small delay, so that the priority queue can sort events
 # properly. This delay is used for the time it takes to generate a

--- a/src/runSimulation.py
+++ b/src/runSimulation.py
@@ -136,7 +136,7 @@ def main():
                             devices[flow_data['flow_dest']],
                             flow_data['data_amt'], flow_data['flow_start'], flow_data['theoRTT'])
         flows[str(flow_name)] = flow
-    print "Flows instantiated: ", "\n\n"
+    print "Flows instantiated.", "\n\n"
 
     # verifying metric inputs from command line are correct
     if args.metrics:
@@ -148,7 +148,6 @@ def main():
             if linkID not in links.keys():
                 print "Bad linkID in argument list."
                 return
-    print "OK!"
 
     network = classes.Network(devices, links, flows)
     met = None
@@ -157,7 +156,9 @@ def main():
     simulator = simulation.Simulator(network, args.tcp_type, met)
 
     # gen routing table
-    print "Static routing:"
+    print "Running..."
+    if args.verbose:
+        print "Static routing:"
 
     simulator.staticRouting()
     while not simulator.q.empty():

--- a/src/simulation.py
+++ b/src/simulation.py
@@ -98,8 +98,7 @@ class Simulator:
         self.network = network
         self.tcp_type = TCP_type
 
-        #keeps track of the first time a packet is acknowledged
-        self.first_time = 0
+
 
         self.metrics = metric
         print self.metrics
@@ -225,7 +224,7 @@ class Simulator:
             #updatewindow, we have to make our RTT higher
             #(before, it was left as the last rtt received, which was deceiving)
             if event.flow.received_packet == False:
-                print "butt last_receieved_packet: " + str(event.flow.last_received_packet_start_time)
+                print "last_receieved_packet: " + str(event.flow.last_received_packet_start_time)
                 #figure out the appropriate value
                 event.flow.actualRTT = event.time - event.flow.last_received_packet_start_time
 
@@ -322,6 +321,7 @@ class Simulator:
              #             " Window Size " + str(event.flow.window_size) '''
 
         elif event.type == "RECEIVE":
+
             # Processes a host/router action that would receive things.
             assert(isinstance(event.handler, Device))
             sendLink = event.packet.currLink
@@ -357,6 +357,7 @@ class Simulator:
 
             # Host receives packet
             elif isinstance(event.handler, Host):
+                print "asdf: " + str(event.flow.flowID)
                 if(event.packet.data_type == "DATA"):
                     host = event.handler
                     host.receive(event.packet)
@@ -390,12 +391,12 @@ class Simulator:
                     if isDropped == False:
 
 
-                        if self.first_time == 0:
+                        if event.flow.first_time == 0:
                             # TCP Fast initialization event, which should happen only the first time a packet is acknowledged
                             if self.tcp_type == 'FAST':
-                                newEvent2 = Event(None, None, "UPDATEWINDOW", event.time + 20, event.flow)
+                                newEvent2 = Event(None, None, "UPDATEWINDOW", event.time + (2*event.flow.actualRTT), event.flow)
                                 self.insertEvent(newEvent2)
-                            self.first_time = 1
+                            event.flow.first_time = 1
 
                         increment = 1
                         result += "event.flow.packets_index: " + str(event.flow.packets_index) + "\n"


### PR DESCRIPTION
OK, so things should run to completion now.
I encountered a strange bug where sometimes an sending an ACK packet would have no flow associated with it. This happened at around 8s, so I'm guessing that this bug occurred due to the new dynamic routing code - the tables are updated every 4s, and "routing packet events" are enqueued with no specified flow.
My theory is that, whenever the tables need to be updated, "routing packet events" are created, but somehow these events are dequeued at the wrong time. Thus, when we dequeue a "send" event that should corresponding to a routing packet, a not-routing packet is at the head of the queue, but no flow is passed in, so the packet loses its associated flow.

My current solution is just to look at the flow's ID from the packet (if it exists), and reassign the flow. However, I believe that such a problem shouldn't have happened in the first place (if we order events correctly). So perhaps the **cmp** function needs tweaking (try giving routing packets lower priority?).

Finally, dynamic routing doesn't appear to change the graphs. The dynamic routing code does execute, but I'm not sure why there's no change.
